### PR TITLE
fix: cached routes for named params

### DIFF
--- a/cmd/recipes/main.go
+++ b/cmd/recipes/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -26,10 +27,14 @@ func NewApp() App {
 	}
 	client := dynamodb.NewFromConfig(cfg)
 	marshaler := token.NewGCM()
+	router, err := routes.NewRouter(
+		recipes.NewRoute(services.NewRecipeService(tableName, *client, marshaler)),
+	)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to cache all routes: %s", err))
+	}
 	return App{
-		Router: *routes.NewRouter(
-			recipes.NewRoute(services.NewRecipeService(tableName, *client, marshaler)),
-		),
+		Router: *router,
 	}
 }
 

--- a/internal/routes/router.go
+++ b/internal/routes/router.go
@@ -16,20 +16,46 @@ type Service interface {
 	GetRoutes() map[string]Route
 }
 
-type Router struct {
-	Routes map[string]Route
+type CachedRoute struct {
+	Method     string
+	Matcher    *regexp.Regexp
+	ParamNames []string
+	Route      Route
 }
 
-func NewRouter(services ...Service) *Router {
-	var routes map[string]Route = make(map[string]Route)
+type Router struct {
+	Routes []CachedRoute
+}
+
+func NewRouter(services ...Service) (*Router, error) {
+	var routes []CachedRoute
 	for _, service := range services {
 		for composite, route := range service.GetRoutes() {
-			routes[composite] = route
+			var names []string
+			parts := strings.SplitN(composite, ":", 2)
+			method := parts[0]
+			path := parts[1]
+			namex := regexp.MustCompile(":[^/]+")
+			regexPath := namex.ReplaceAllStringFunc(path, func(found string) string {
+				names = append(names, found[1:])
+				return "([^/]+)"
+			})
+			reg, err := regexp.Compile("^" + regexPath + "$")
+			if err != nil {
+				return nil, err
+			}
+			cachedRoute := CachedRoute{
+				Method:     method,
+				Matcher:    reg,
+				ParamNames: names,
+				Route:      route,
+			}
+			routes = append(routes, cachedRoute)
 		}
 	}
 	return &Router{
 		Routes: routes,
-	}
+	}, nil
 }
 
 func translateError(err error) events.APIGatewayV2HTTPResponse {
@@ -53,21 +79,16 @@ func translateError(err error) events.APIGatewayV2HTTPResponse {
 }
 
 func (r *Router) Invoke(event events.APIGatewayV2HTTPRequest, ctx context.Context) events.APIGatewayV2HTTPResponse {
-	for composite, route := range r.Routes {
-		parts := strings.SplitN(composite, ":", 2)
-		method := parts[0]
-		path := parts[1]
-		if event.RequestContext.HTTP.Method != method {
+	for _, route := range r.Routes {
+		if route.Method != event.RequestContext.HTTP.Method {
 			continue
 		}
-		regexPath := strings.ReplaceAll(path, ":id", "[^/]+")
-		reg, err := regexp.Compile("^" + regexPath + "$")
-		if err != nil {
-			return translateError(err)
-		}
-		if reg.MatchString(event.RawPath) {
-			// TODO: add parameter values to ctx
-			resp, err := route(event, ctx)
+		if values := route.Matcher.FindAllStringSubmatchIndex(event.RawPath, -1); values != nil {
+			params := make(map[string]string, len(route.ParamNames))
+			for i, p := range route.ParamNames {
+				params[p] = event.RawPath[values[0][i+2]:values[0][i+3]]
+			}
+			resp, err := route.Route(event, context.WithValue(ctx, "Params", params))
 			if err != nil {
 				return translateError(err)
 			}

--- a/internal/routes/router_test.go
+++ b/internal/routes/router_test.go
@@ -114,12 +114,16 @@ func NewLocalServer(t *testing.T) *LocalServer {
 		t.Fatalf("Failed to create DDB table: %s", err)
 	}
 	t.Logf("Successfully created local resources running on %d", LOCAL_DDB_PORT)
-	return &LocalServer{
-		Router: routes.NewRouter(
-			recipes.NewRoute(
-				services.NewRecipeService(tableName, *client, token.NewGCM()),
-			),
+	router, err := routes.NewRouter(
+		recipes.NewRoute(
+			services.NewRecipeService(tableName, *client, token.NewGCM()),
 		),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create a router: %s", err)
+	}
+	return &LocalServer{
+		Router: router,
 	}
 }
 

--- a/internal/routes/util/helpers.go
+++ b/internal/routes/util/helpers.go
@@ -20,6 +20,14 @@ func AuthorizedRoute(route routes.Route) routes.Route {
 	}
 }
 
+func RequestParam(ctx context.Context, param string) string {
+	return ctx.Value("Params").(map[string]string)[param]
+}
+
+func Username(ctx context.Context) string {
+	return ctx.Value("Username").(string)
+}
+
 func SerializeResponse[T interface{}, R interface{}](delayed func(T) R, thing T, err error, statusCode int) (events.APIGatewayV2HTTPResponse, error) {
 	if err != nil {
 		return events.APIGatewayV2HTTPResponse{}, err


### PR DESCRIPTION
- Adds some "cold start" caching for named parameters in route validation
- Next step would be a "lazy" cache, which can be accomplished with the `CachedRoute` struct
- Adds more helpers to get things out of the context