### PR TITLE
fix: allow logins to use providers

### DIFF
--- a/cmd/auth/main.go
+++ b/cmd/auth/main.go
@@ -56,6 +56,7 @@ func JWTAuthThunk(ctx context.Context, apiToken string) (*events.APIGatewayV2Cus
 				string(data.SETTINGS_WRITE),
 				string(data.AUDIT_WRITE),
 				string(data.SHARE_WRITE),
+				string(data.PROVIDER_WRITE),
 			},
 		},
 	}, nil

--- a/internal/data/apitokens.go
+++ b/internal/data/apitokens.go
@@ -20,6 +20,7 @@ const (
 	TOKENS_READ         Scope = "tokens.readonly"
 	TOKENS_WRITE        Scope = "tokens"
 	PROVIDER_READ       Scope = "providers.readonly"
+	PROVIDER_WRITE      Scope = "providers"
 )
 
 type ApiTokenDTO struct {


### PR DESCRIPTION
- Adding the provider scope to web auths